### PR TITLE
[機能追加] ニュース投稿機能・お問い合わせ機能を実装

### DIFF
--- a/java_spring_app/src/main/java/com/example/its/config/SecurityConfig.java
+++ b/java_spring_app/src/main/java/com/example/its/config/SecurityConfig.java
@@ -8,36 +8,45 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 
 import lombok.RequiredArgsConstructor;
+
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
     private final UserDetailsService userDetailsService;
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-    	
-    	// for h2-console
+
+        // for h2-console
         http
                 .authorizeRequests().antMatchers("/h2-console/**").permitAll()
                 .and()
                 .csrf().ignoringAntMatchers("/h2-console/**")
                 .and()
                 .headers().frameOptions().disable();
-    	
-    	
+
         http
                 .authorizeRequests()
                 .mvcMatchers("/login/**").permitAll()
+                .mvcMatchers("/contacts/**").permitAll()
+                .mvcMatchers("/informations/**").hasRole("ADMIN")
+                .mvcMatchers("/admin/**").hasRole("ADMIN")
                 .anyRequest().authenticated()
                 .and()
                 .formLogin()
-                .loginPage("/login");
+                .loginPage("/login")
+                .and()
+                .logout()
+                .logoutUrl("/logout")
+                .logoutSuccessUrl("/login?logout")
+                .invalidateHttpSession(true)
+                .deleteCookies("JSESSIONID");
     }
-    
+
     @Override
     protected void configure(AuthenticationManagerBuilder auth) throws Exception {
-    	auth.userDetailsService(userDetailsService)
-        .passwordEncoder(NoOpPasswordEncoder.getInstance());
+        auth.userDetailsService(userDetailsService)
+                .passwordEncoder(NoOpPasswordEncoder.getInstance());
     }
-    
 }

--- a/java_spring_app/src/main/java/com/example/its/domain/auth/CustomUserDetailsService.java
+++ b/java_spring_app/src/main/java/com/example/its/domain/auth/CustomUserDetailsService.java
@@ -1,7 +1,8 @@
 package com.example.its.domain.auth;
 
-import java.util.Collections;
+import java.util.List;
 
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -17,18 +18,18 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-    	  return userRepository.findByUsername(username)
-                  .map(
-                          user -> new CustomUserDetails(
-                                  user.getUsername(),
-                                  user.getPassword(),
-                                  Collections.emptyList()
-                          )
-                  )
-                  .orElseThrow(
-                          () -> new UsernameNotFoundException(
-                                  "Given username is not found. (username = '" + username + "')"
-                          )
-                  );
-      }
-  }
+        return userRepository.findByUsername(username)
+                .map(
+                        user -> new CustomUserDetails(
+                                user.getUsername(),
+                                user.getPassword(),
+                                List.of(new SimpleGrantedAuthority(user.getRole()))
+                        )
+                )
+                .orElseThrow(
+                        () -> new UsernameNotFoundException(
+                                "Given username is not found. (username = '" + username + "')"
+                        )
+                );
+    }
+}

--- a/java_spring_app/src/main/java/com/example/its/domain/auth/User.java
+++ b/java_spring_app/src/main/java/com/example/its/domain/auth/User.java
@@ -9,4 +9,5 @@ public class User {
 
     private String username;
     private String password;
+    private String role;
 }

--- a/java_spring_app/src/main/java/com/example/its/domain/contact/ContactEntity.java
+++ b/java_spring_app/src/main/java/com/example/its/domain/contact/ContactEntity.java
@@ -1,0 +1,18 @@
+package com.example.its.domain.contact;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@AllArgsConstructor
+@Data
+public class ContactEntity {
+    private long id;
+    private String name;
+    private String email;
+    private String subject;
+    private String message;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/java_spring_app/src/main/java/com/example/its/domain/contact/ContactRepository.java
+++ b/java_spring_app/src/main/java/com/example/its/domain/contact/ContactRepository.java
@@ -1,0 +1,25 @@
+package com.example.its.domain.contact;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+
+@Mapper
+public interface ContactRepository {
+
+    @Select("select * from contacts order by created_at desc")
+    List<ContactEntity> findAll();
+
+    @Select("select * from contacts where id = #{id}")
+    Optional<ContactEntity> findById(long id);
+
+    @Insert("insert into contacts (name, email, subject, message) values (#{name}, #{email}, #{subject}, #{message})")
+    void insert(String name, String email, String subject, String message);
+
+    @Delete("delete from contacts where id = #{id}")
+    void delete(long id);
+}

--- a/java_spring_app/src/main/java/com/example/its/domain/contact/ContactService.java
+++ b/java_spring_app/src/main/java/com/example/its/domain/contact/ContactService.java
@@ -1,0 +1,31 @@
+package com.example.its.domain.contact;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ContactService {
+
+    private final ContactRepository contactRepository;
+
+    public List<ContactEntity> findAll() {
+        return contactRepository.findAll();
+    }
+
+    public ContactEntity findById(long id) {
+        return contactRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Contact not found. id=" + id));
+    }
+
+    public void create(String name, String email, String subject, String message) {
+        contactRepository.insert(name, email, subject, message);
+    }
+
+    public void delete(long id) {
+        contactRepository.delete(id);
+    }
+}

--- a/java_spring_app/src/main/java/com/example/its/domain/information/InformationEntity.java
+++ b/java_spring_app/src/main/java/com/example/its/domain/information/InformationEntity.java
@@ -1,0 +1,16 @@
+package com.example.its.domain.information;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@AllArgsConstructor
+@Data
+public class InformationEntity {
+    private long id;
+    private String informationTitle;
+    private String informationDetail;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/java_spring_app/src/main/java/com/example/its/domain/information/InformationRepository.java
+++ b/java_spring_app/src/main/java/com/example/its/domain/information/InformationRepository.java
@@ -1,0 +1,29 @@
+package com.example.its.domain.information;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
+
+@Mapper
+public interface InformationRepository {
+
+    @Select("select * from informations order by created_at desc")
+    List<InformationEntity> findAll();
+
+    @Select("select * from informations where id = #{id}")
+    Optional<InformationEntity> findById(long id);
+
+    @Insert("insert into informations (information_title, information_detail) values (#{informationTitle}, #{informationDetail})")
+    void insert(String informationTitle, String informationDetail);
+
+    @Update("update informations set information_title = #{informationTitle}, information_detail = #{informationDetail} where id = #{id}")
+    void update(long id, String informationTitle, String informationDetail);
+
+    @Delete("delete from informations where id = #{id}")
+    void delete(long id);
+}

--- a/java_spring_app/src/main/java/com/example/its/domain/information/InformationService.java
+++ b/java_spring_app/src/main/java/com/example/its/domain/information/InformationService.java
@@ -1,0 +1,35 @@
+package com.example.its.domain.information;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class InformationService {
+
+    private final InformationRepository informationRepository;
+
+    public List<InformationEntity> findAll() {
+        return informationRepository.findAll();
+    }
+
+    public InformationEntity findById(long id) {
+        return informationRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Information not found. id=" + id));
+    }
+
+    public void create(String informationTitle, String informationDetail) {
+        informationRepository.insert(informationTitle, informationDetail);
+    }
+
+    public void update(long id, String informationTitle, String informationDetail) {
+        informationRepository.update(id, informationTitle, informationDetail);
+    }
+
+    public void delete(long id) {
+        informationRepository.delete(id);
+    }
+}

--- a/java_spring_app/src/main/java/com/example/its/web/contact/AdminContactController.java
+++ b/java_spring_app/src/main/java/com/example/its/web/contact/AdminContactController.java
@@ -1,0 +1,36 @@
+package com.example.its.web.contact;
+
+import com.example.its.domain.contact.ContactService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/admin/contacts")
+@RequiredArgsConstructor
+public class AdminContactController {
+
+    private final ContactService contactService;
+
+    @GetMapping
+    public String showList(Model model) {
+        model.addAttribute("contactList", contactService.findAll());
+        return "admin/contacts/list";
+    }
+
+    @GetMapping("/{contactId}")
+    public String showDetail(@PathVariable("contactId") long contactId, Model model) {
+        model.addAttribute("contact", contactService.findById(contactId));
+        return "admin/contacts/detail";
+    }
+
+    @DeleteMapping("/{contactId}")
+    public String delete(@PathVariable("contactId") long contactId) {
+        contactService.delete(contactId);
+        return "redirect:/admin/contacts";
+    }
+}

--- a/java_spring_app/src/main/java/com/example/its/web/contact/ContactController.java
+++ b/java_spring_app/src/main/java/com/example/its/web/contact/ContactController.java
@@ -1,0 +1,47 @@
+package com.example.its.web.contact;
+
+import com.example.its.domain.contact.ContactService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/contacts")
+@RequiredArgsConstructor
+public class ContactController {
+
+    private final ContactService contactService;
+
+    @GetMapping("/new")
+    public String showForm(@ModelAttribute ContactForm form) {
+        return "contacts/new";
+    }
+
+    @PostMapping("/confirm")
+    public String confirm(@Validated ContactForm form, BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            return "contacts/new";
+        }
+        return "contacts/confirm";
+    }
+
+    @PostMapping
+    public String create(@Validated ContactForm form, BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            return "contacts/new";
+        }
+        contactService.create(form.getName(), form.getEmail(), form.getSubject(), form.getMessage());
+        return "redirect:/contacts/finish";
+    }
+
+    @GetMapping("/finish")
+    public String finish() {
+        return "contacts/finish";
+    }
+}

--- a/java_spring_app/src/main/java/com/example/its/web/contact/ContactForm.java
+++ b/java_spring_app/src/main/java/com/example/its/web/contact/ContactForm.java
@@ -1,0 +1,28 @@
+package com.example.its.web.contact;
+
+import lombok.Data;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@Data
+public class ContactForm {
+
+    @NotBlank
+    @Size(max = 100)
+    private String name;
+
+    @NotBlank
+    @Email
+    @Size(max = 256)
+    private String email;
+
+    @NotBlank
+    @Size(max = 256)
+    private String subject;
+
+    @NotBlank
+    @Size(max = 2000)
+    private String message;
+}

--- a/java_spring_app/src/main/java/com/example/its/web/information/InformationController.java
+++ b/java_spring_app/src/main/java/com/example/its/web/information/InformationController.java
@@ -1,0 +1,77 @@
+package com.example.its.web.information;
+
+import com.example.its.domain.information.InformationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/informations")
+@RequiredArgsConstructor
+public class InformationController {
+
+    private final InformationService informationService;
+
+    @GetMapping
+    public String showList(Model model) {
+        model.addAttribute("informationList", informationService.findAll());
+        return "informations/list";
+    }
+
+    @GetMapping("/creationForm")
+    public String showCreationForm(@ModelAttribute InformationForm form) {
+        return "informations/creationForm";
+    }
+
+    @PostMapping
+    public String create(@Validated InformationForm form, BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            return showCreationForm(form);
+        }
+        informationService.create(form.getInformationTitle(), form.getInformationDetail());
+        return "redirect:/informations";
+    }
+
+    @GetMapping("/{informationId}")
+    public String showDetail(@PathVariable("informationId") long informationId, Model model) {
+        model.addAttribute("information", informationService.findById(informationId));
+        return "informations/detail";
+    }
+
+    @GetMapping("/{informationId}/editForm")
+    public String showEditForm(@PathVariable("informationId") long informationId, Model model) {
+        var information = informationService.findById(informationId);
+        var form = new InformationForm();
+        form.setInformationTitle(information.getInformationTitle());
+        form.setInformationDetail(information.getInformationDetail());
+        model.addAttribute("informationForm", form);
+        model.addAttribute("informationId", informationId);
+        return "informations/editForm";
+    }
+
+    @PutMapping("/{informationId}")
+    public String update(@PathVariable("informationId") long informationId,
+                         @Validated InformationForm form, BindingResult bindingResult, Model model) {
+        if (bindingResult.hasErrors()) {
+            model.addAttribute("informationId", informationId);
+            return "informations/editForm";
+        }
+        informationService.update(informationId, form.getInformationTitle(), form.getInformationDetail());
+        return "redirect:/informations/" + informationId;
+    }
+
+    @DeleteMapping("/{informationId}")
+    public String delete(@PathVariable("informationId") long informationId) {
+        informationService.delete(informationId);
+        return "redirect:/informations";
+    }
+}

--- a/java_spring_app/src/main/java/com/example/its/web/information/InformationForm.java
+++ b/java_spring_app/src/main/java/com/example/its/web/information/InformationForm.java
@@ -1,0 +1,18 @@
+package com.example.its.web.information;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@Data
+public class InformationForm {
+
+    @NotBlank
+    @Size(max = 256)
+    private String informationTitle;
+
+    @NotBlank
+    @Size(max = 2000)
+    private String informationDetail;
+}

--- a/java_spring_app/src/main/resources/application.properties
+++ b/java_spring_app/src/main/resources/application.properties
@@ -3,3 +3,4 @@ spring.datasource.data-source-class-name=org.h2.Driver
 spring.datasource.url=jdbc:h2:mem:its;DB_CLOSE_ON_EXIT=TRUE;MODE=MySQL
 spring.datasource.username=sa
 spring.datasource.password=
+spring.mvc.hiddenmethod.filter.enabled=true

--- a/java_spring_app/src/main/resources/data.sql
+++ b/java_spring_app/src/main/resources/data.sql
@@ -2,5 +2,6 @@ insert into issues (summary, description) values ('バグA', 'バグがありま
 insert into issues (summary, description) values ('機能要望B', 'Bに追加機能がほしいです');
 insert into issues (summary, description) values ('画面Cが遅い', '早くしてほしいです');
 
-insert into users (username, password) values ('tom', 'password');
-insert into users (username, password) values ('bob', 'password');
+insert into users (username, password, role) values ('admin', 'password', 'ROLE_ADMIN');
+insert into users (username, password, role) values ('tom', 'password', 'ROLE_USER');
+insert into users (username, password, role) values ('bob', 'password', 'ROLE_USER');

--- a/java_spring_app/src/main/resources/logout.html
+++ b/java_spring_app/src/main/resources/logout.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{fragments/layout :: layout(~{::title}, ~{::body})}">
+<head>
+    <title>ログアウトページ | 課題管理アプリケーション</title>
+</head>
+<body>
+<h1 class="mt-3">課題管理アプリケーション</h1>
+<form action="#" th:action="@{/logout}" method="post">
+    <div class="mt-3">
+        <button type="submit" class="btn btn-primary">ログアウト</button>
+    </div>
+</form>
+</body>
+</html>

--- a/java_spring_app/src/main/resources/schema.sql
+++ b/java_spring_app/src/main/resources/schema.sql
@@ -1,10 +1,29 @@
 create table issues (
 id BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT,
-summary VARCHAR(256) NOT NULl,
-description VARCHAR(256) NOT NULl
+summary VARCHAR(256) NOT NULL,
+description VARCHAR(256) NOT NULL
 );
 
 create table users (
 username varchar(50) not null primary key,
-password varchar(500) not null
+password varchar(500) not null,
+role varchar(50) not null default 'ROLE_USER'
+);
+
+create table informations (
+id BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+information_title VARCHAR(256) NOT NULL,
+information_detail VARCHAR(2000) NOT NULL,
+created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+create table contacts (
+id BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+name VARCHAR(100) NOT NULL,
+email VARCHAR(256) NOT NULL,
+subject VARCHAR(256) NOT NULL,
+message TEXT NOT NULL,
+created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );

--- a/java_spring_app/src/main/resources/templates/admin/contacts/detail.html
+++ b/java_spring_app/src/main/resources/templates/admin/contacts/detail.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{fragments/layout :: layout(~{::title}, ~{::body})}">
+<head>
+    <title>お問い合わせ詳細（管理者） | 課題管理アプリケーション</title>
+</head>
+<body>
+<h1 class="mt-3">お問い合わせ詳細</h1>
+<table class="table">
+    <tr>
+        <th style="width: 150px;">ID</th>
+        <td th:text="${contact.id}"></td>
+    </tr>
+    <tr>
+        <th>お名前</th>
+        <td th:text="${contact.name}"></td>
+    </tr>
+    <tr>
+        <th>メールアドレス</th>
+        <td th:text="${contact.email}"></td>
+    </tr>
+    <tr>
+        <th>件名</th>
+        <td th:text="${contact.subject}"></td>
+    </tr>
+    <tr>
+        <th>お問い合わせ内容</th>
+        <td th:text="${contact.message}" style="white-space: pre-wrap;"></td>
+    </tr>
+    <tr>
+        <th>受信日時</th>
+        <td th:text="${#temporals.format(contact.createdAt, 'yyyy/MM/dd HH:mm')}"></td>
+    </tr>
+</table>
+<a th:href="@{/admin/contacts}" class="btn btn-secondary">一覧へ戻る</a>
+<form th:action="@{/admin/contacts/{id}(id=${contact.id})}" method="post" style="display:inline;">
+    <input type="hidden" name="_method" value="delete">
+    <button type="submit" class="btn btn-danger ms-2"
+            onclick="return confirm('このお問い合わせを削除しますか？')">削除</button>
+</form>
+</body>
+</html>

--- a/java_spring_app/src/main/resources/templates/admin/contacts/list.html
+++ b/java_spring_app/src/main/resources/templates/admin/contacts/list.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{fragments/layout :: layout(~{::title}, ~{::body})}">
+<head>
+    <title>お問い合わせ一覧（管理者） | 課題管理アプリケーション</title>
+</head>
+<body>
+<h1 class="mt-3">お問い合わせ一覧</h1>
+<table class="table">
+    <thead>
+    <tr>
+        <th>ID</th>
+        <th>お名前</th>
+        <th>件名</th>
+        <th>受信日時</th>
+        <th></th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr th:each="contact : ${contactList}">
+        <td th:text="${contact.id}"></td>
+        <td th:text="${contact.name}"></td>
+        <td th:text="${contact.subject}"></td>
+        <td th:text="${#temporals.format(contact.createdAt, 'yyyy/MM/dd HH:mm')}"></td>
+        <td>
+            <a th:href="@{/admin/contacts/{id}(id=${contact.id})}" class="btn btn-sm btn-outline-primary">詳細</a>
+            <form th:action="@{/admin/contacts/{id}(id=${contact.id})}" method="post" style="display:inline;">
+                <input type="hidden" name="_method" value="delete">
+                <button type="submit" class="btn btn-sm btn-outline-danger ms-1"
+                        onclick="return confirm('このお問い合わせを削除しますか？')">削除</button>
+            </form>
+        </td>
+    </tr>
+    </tbody>
+</table>
+<a th:href="@{/}">トップへ戻る</a>
+</body>
+</html>

--- a/java_spring_app/src/main/resources/templates/contacts/confirm.html
+++ b/java_spring_app/src/main/resources/templates/contacts/confirm.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{fragments/layout :: layout(~{::title}, ~{::body})}">
+<head>
+    <title>お問い合わせ確認 | 課題管理アプリケーション</title>
+</head>
+<body>
+<h1 class="mt-3">お問い合わせ内容の確認</h1>
+<p class="text-muted">以下の内容でよろしいですか？</p>
+<table class="table">
+    <tr>
+        <th style="width: 150px;">お名前</th>
+        <td th:text="${contactForm.name}"></td>
+    </tr>
+    <tr>
+        <th>メールアドレス</th>
+        <td th:text="${contactForm.email}"></td>
+    </tr>
+    <tr>
+        <th>件名</th>
+        <td th:text="${contactForm.subject}"></td>
+    </tr>
+    <tr>
+        <th>お問い合わせ内容</th>
+        <td th:text="${contactForm.message}" style="white-space: pre-wrap;"></td>
+    </tr>
+</table>
+
+<form th:action="@{/contacts}" th:object="${contactForm}" method="post">
+    <input type="hidden" th:field="*{name}">
+    <input type="hidden" th:field="*{email}">
+    <input type="hidden" th:field="*{subject}">
+    <input type="hidden" th:field="*{message}">
+    <button type="submit" class="btn btn-primary">送信する</button>
+    <a th:href="@{/contacts/new}" class="btn btn-secondary ms-2">修正する</a>
+</form>
+</body>
+</html>

--- a/java_spring_app/src/main/resources/templates/contacts/finish.html
+++ b/java_spring_app/src/main/resources/templates/contacts/finish.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{fragments/layout :: layout(~{::title}, ~{::body})}">
+<head>
+    <title>お問い合わせ完了 | 課題管理アプリケーション</title>
+</head>
+<body>
+<div class="mt-5 text-center">
+    <h1>お問い合わせを受け付けました</h1>
+    <p class="mt-3 text-muted">ご連絡いただきありがとうございます。<br>内容を確認の上、担当者よりご連絡いたします。</p>
+    <a th:href="@{/}" class="btn btn-primary mt-3">トップページへ戻る</a>
+</div>
+</body>
+</html>

--- a/java_spring_app/src/main/resources/templates/contacts/new.html
+++ b/java_spring_app/src/main/resources/templates/contacts/new.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{fragments/layout :: layout(~{::title}, ~{::body})}">
+<head>
+    <title>お問い合わせ | 課題管理アプリケーション</title>
+</head>
+<body>
+<h1 class="mt-3">お問い合わせ</h1>
+<form th:action="@{/contacts/confirm}" th:object="${contactForm}" method="post">
+    <div class="mb-3">
+        <label for="name" class="form-label">お名前 <span class="text-danger">*</span></label>
+        <input type="text" class="form-control" id="name" th:field="*{name}" placeholder="例）山田 太郎">
+        <div class="text-danger" th:if="${#fields.hasErrors('name')}" th:errors="*{name}"></div>
+    </div>
+    <div class="mb-3">
+        <label for="email" class="form-label">メールアドレス <span class="text-danger">*</span></label>
+        <input type="email" class="form-control" id="email" th:field="*{email}" placeholder="例）example@mail.com">
+        <div class="text-danger" th:if="${#fields.hasErrors('email')}" th:errors="*{email}"></div>
+    </div>
+    <div class="mb-3">
+        <label for="subject" class="form-label">件名 <span class="text-danger">*</span></label>
+        <input type="text" class="form-control" id="subject" th:field="*{subject}">
+        <div class="text-danger" th:if="${#fields.hasErrors('subject')}" th:errors="*{subject}"></div>
+    </div>
+    <div class="mb-3">
+        <label for="message" class="form-label">お問い合わせ内容 <span class="text-danger">*</span></label>
+        <textarea class="form-control" id="message" th:field="*{message}" rows="6"></textarea>
+        <div class="text-danger" th:if="${#fields.hasErrors('message')}" th:errors="*{message}"></div>
+    </div>
+    <button type="submit" class="btn btn-primary">確認画面へ</button>
+</form>
+</body>
+</html>

--- a/java_spring_app/src/main/resources/templates/fragments/layout.html
+++ b/java_spring_app/src/main/resources/templates/fragments/layout.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org" th:fragment="layout(title, content)">
+<html lang="ja" xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
+      th:fragment="layout(title, content)">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -7,6 +9,17 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
 </head>
 <body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark" sec:authorize="isAuthenticated()">
+    <div class="container">
+        <a class="navbar-brand" th:href="@{/}">課題管理アプリ</a>
+        <div class="ms-auto d-flex align-items-center">
+            <span class="text-white me-3" sec:authentication="name"></span>
+            <form th:action="@{/logout}" method="post" class="mb-0">
+                <button type="submit" class="btn btn-outline-light btn-sm">ログアウト</button>
+            </form>
+        </div>
+    </div>
+</nav>
 <div class="container" th:insert="${content}"></div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
 </body>

--- a/java_spring_app/src/main/resources/templates/index.html
+++ b/java_spring_app/src/main/resources/templates/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
       th:replace="~{fragments/layout :: layout(~{::title}, ~{::body})}">
 <head>
     <title>トップページ | 課題管理アプリケーション</title>
@@ -8,10 +9,16 @@
 <h1 class="mt-3">課題管理アプリケーション</h1>
 <ul>
     <li>
-        <a href="./issues/list.html" th:href="@{/issues}">課題一覧</a>
+        <a th:href="@{/issues}">課題一覧</a>
     </li>
     <li>
-        <a href="/test.html" th:href="@{/test}">テスト</a>
+        <a th:href="@{/contacts/new}">お問い合わせ</a>
+    </li>
+    <li sec:authorize="hasRole('ADMIN')">
+        <a th:href="@{/informations}">ニュース管理（管理者専用）</a>
+    </li>
+    <li sec:authorize="hasRole('ADMIN')">
+        <a th:href="@{/admin/contacts}">お問い合わせ管理（管理者専用）</a>
     </li>
 </ul>
 </body>

--- a/java_spring_app/src/main/resources/templates/index.html
+++ b/java_spring_app/src/main/resources/templates/index.html
@@ -9,7 +9,10 @@
 <h1 class="mt-3">課題管理アプリケーション</h1>
 <ul>
     <li>
-        <a th:href="@{/issues}">課題一覧</a>
+        <a href="./issues/list.html" th:href="@{/issues}">課題一覧</a>
+    </li>
+    <li>
+        <a href="/test.html" th:href="@{/test}">テスト</a>
     </li>
     <li>
         <a th:href="@{/contacts/new}">お問い合わせ</a>

--- a/java_spring_app/src/main/resources/templates/informations/creationForm.html
+++ b/java_spring_app/src/main/resources/templates/informations/creationForm.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{fragments/layout :: layout(~{::title}, ~{::body})}">
+<head>
+    <title>ニュース投稿 | 課題管理アプリケーション</title>
+</head>
+<body>
+<h1 class="mt-3">ニュース投稿</h1>
+<form th:action="@{/informations}" th:object="${informationForm}" method="post">
+    <div class="mb-3">
+        <label for="informationTitle" class="form-label">タイトル</label>
+        <input type="text" class="form-control" id="informationTitle" th:field="*{informationTitle}">
+        <div class="text-danger" th:if="${#fields.hasErrors('informationTitle')}" th:errors="*{informationTitle}"></div>
+    </div>
+    <div class="mb-3">
+        <label for="informationDetail" class="form-label">内容</label>
+        <textarea class="form-control" id="informationDetail" th:field="*{informationDetail}" rows="6"></textarea>
+        <div class="text-danger" th:if="${#fields.hasErrors('informationDetail')}" th:errors="*{informationDetail}"></div>
+    </div>
+    <button type="submit" class="btn btn-primary">投稿する</button>
+    <a th:href="@{/informations}" class="btn btn-secondary ms-2">キャンセル</a>
+</form>
+</body>
+</html>

--- a/java_spring_app/src/main/resources/templates/informations/detail.html
+++ b/java_spring_app/src/main/resources/templates/informations/detail.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{fragments/layout :: layout(~{::title}, ~{::body})}">
+<head>
+    <title>ニュース詳細 | 課題管理アプリケーション</title>
+</head>
+<body>
+<h1 class="mt-3">ニュース詳細</h1>
+<table class="table">
+    <tr>
+        <th>ID</th>
+        <td th:text="${information.id}"></td>
+    </tr>
+    <tr>
+        <th>タイトル</th>
+        <td th:text="${information.informationTitle}"></td>
+    </tr>
+    <tr>
+        <th>内容</th>
+        <td th:text="${information.informationDetail}" style="white-space: pre-wrap;"></td>
+    </tr>
+    <tr>
+        <th>投稿日時</th>
+        <td th:text="${#temporals.format(information.createdAt, 'yyyy/MM/dd HH:mm')}"></td>
+    </tr>
+    <tr>
+        <th>更新日時</th>
+        <td th:text="${#temporals.format(information.updatedAt, 'yyyy/MM/dd HH:mm')}"></td>
+    </tr>
+</table>
+<a th:href="@{/informations}" class="btn btn-secondary">一覧へ戻る</a>
+<a th:href="@{/informations/{id}/editForm(id=${information.id})}" class="btn btn-primary ms-2">編集</a>
+<form th:action="@{/informations/{id}(id=${information.id})}" method="post" style="display:inline;">
+    <input type="hidden" name="_method" value="delete">
+    <button type="submit" class="btn btn-danger ms-2"
+            onclick="return confirm('このニュースを削除しますか？')">削除</button>
+</form>
+</body>
+</html>

--- a/java_spring_app/src/main/resources/templates/informations/editForm.html
+++ b/java_spring_app/src/main/resources/templates/informations/editForm.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{fragments/layout :: layout(~{::title}, ~{::body})}">
+<head>
+    <title>ニュース編集 | 課題管理アプリケーション</title>
+</head>
+<body>
+<h1 class="mt-3">ニュース編集</h1>
+<form th:action="@{/informations/{id}(id=${informationId})}" th:object="${informationForm}" method="post">
+    <input type="hidden" name="_method" value="put">
+    <div class="mb-3">
+        <label for="informationTitle" class="form-label">タイトル</label>
+        <input type="text" class="form-control" id="informationTitle" th:field="*{informationTitle}">
+        <div class="text-danger" th:if="${#fields.hasErrors('informationTitle')}" th:errors="*{informationTitle}"></div>
+    </div>
+    <div class="mb-3">
+        <label for="informationDetail" class="form-label">内容</label>
+        <textarea class="form-control" id="informationDetail" th:field="*{informationDetail}" rows="6"></textarea>
+        <div class="text-danger" th:if="${#fields.hasErrors('informationDetail')}" th:errors="*{informationDetail}"></div>
+    </div>
+    <button type="submit" class="btn btn-primary">更新する</button>
+    <a th:href="@{/informations/{id}(id=${informationId})}" class="btn btn-secondary ms-2">キャンセル</a>
+</form>
+</body>
+</html>

--- a/java_spring_app/src/main/resources/templates/informations/list.html
+++ b/java_spring_app/src/main/resources/templates/informations/list.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{fragments/layout :: layout(~{::title}, ~{::body})}">
+<head>
+    <title>ニュース一覧 | 課題管理アプリケーション</title>
+</head>
+<body>
+<h1 class="mt-3">ニュース一覧</h1>
+<a th:href="@{/informations/creationForm}" class="btn btn-primary mb-3">新規投稿</a>
+<table class="table">
+    <thead>
+    <tr>
+        <th>ID</th>
+        <th>タイトル</th>
+        <th>投稿日時</th>
+        <th></th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr th:each="information : ${informationList}">
+        <td th:text="${information.id}"></td>
+        <td th:text="${information.informationTitle}"></td>
+        <td th:text="${#temporals.format(information.createdAt, 'yyyy/MM/dd HH:mm')}"></td>
+        <td>
+            <a th:href="@{/informations/{id}(id=${information.id})}" class="btn btn-sm btn-outline-primary">詳細</a>
+            <a th:href="@{/informations/{id}/editForm(id=${information.id})}" class="btn btn-sm btn-outline-secondary ms-1">編集</a>
+            <form th:action="@{/informations/{id}(id=${information.id})}" method="post" style="display:inline;">
+                <input type="hidden" name="_method" value="delete">
+                <button type="submit" class="btn btn-sm btn-outline-danger ms-1"
+                        onclick="return confirm('このニュースを削除しますか？')">削除</button>
+            </form>
+        </td>
+    </tr>
+    </tbody>
+</table>
+<a th:href="@{/}">トップへ戻る</a>
+</body>
+</html>

--- a/java_spring_app/src/main/resources/templates/login.html
+++ b/java_spring_app/src/main/resources/templates/login.html
@@ -6,7 +6,9 @@
 </head>
 <body>
 <h1 class="mt-3">課題管理アプリケーション</h1>
-	<form action="#" th:action="@{/login}" method="post">
+<div class="alert alert-success mt-3" th:if="${param.logout}">ログアウトしました。</div>
+<div class="alert alert-danger mt-3" th:if="${param.error}">ユーザー名またはパスワードが正しくありません。</div>
+<form action="#" th:action="@{/login}" method="post">
     <div class="mt-3">
         <label for="usernameInput" class="form-label">ユーザー名</label>
         <input type="text" id="usernameInput" name="username" class="form-control">


### PR DESCRIPTION
## 概要
設計書（機能構成・詳細設計・テーブル定義書）に基づき、
管理者専用のニュース投稿機能と、非ログインでも利用可能な
お問い合わせ機能を実装しました。

## 変更内容

**DB**
- usersテーブルにroleカラムを追加（ROLE_ADMIN / ROLE_USER）
- informationsテーブルを新規作成
  - information_title, information_detail, created_at, updated_at
- contactsテーブルを新規作成
  - name, email, subject, message, created_at, updated_at

**セキュリティ**
- DBのroleをGrantedAuthorityに反映（CustomUserDetailsService）
- /informations/** をADMINロールのみアクセス可能に制限
- /contacts/** を非ログインでもアクセス可能に設定
- /admin/contacts/** をADMINロールのみアクセス可能に制限
- ログアウト機能を追加（SecurityConfig）

**ドメイン層**
- InformationEntity / InformationRepository / InformationService を作成
- ContactEntity / ContactRepository / ContactService を作成

**Web層**
- InformationController（一覧・投稿・詳細・編集・削除）
- InformationForm（バリデーション付き）
- ContactController（フォーム・確認・完了）
- AdminContactController（一覧・詳細・削除）
- ContactForm（バリデーション付き）

**テンプレート**
- informations/list, creationForm, detail, editForm
- contacts/new, confirm, finish
- admin/contacts/list, detail
- layout.html にナビバー・ログアウトボタンを追加

## 動作確認

**ニュース投稿機能**
- [ ] admin / password でログインできる
- [ ] 一般ユーザー（tom）で /informations にアクセスすると403になる
- [ ] ニュースを新規投稿できる
- [ ] ニュース一覧に投稿した内容が表示される
- [ ] ニュース詳細が表示される
- [ ] ニュースを編集できる
- [ ] ニュースを削除できる
- [ ] ログアウトボタンでログイン画面に戻る

**お問い合わせ機能**
- [ ] 非ログインでお問い合わせフォームにアクセスできる
- [ ] バリデーションエラーが正しく表示される
- [ ] 確認画面で入力内容が正しく表示される
- [ ] 「修正する」ボタンで入力画面に戻れる
- [ ] 送信後、完了画面が表示される
- [ ] 管理者でお問い合わせ一覧・詳細が表示される
- [ ] 管理者でお問い合わせを削除できる